### PR TITLE
nix: 2023-06-17 inputs update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,34 @@
+## Update 2023-06-17
+```go
+Version changes:
+[U.]  #1  tree  2.0.4 -> 2.1.1
+Closure size: 681 -> 681 (5 paths added, 5 paths removed, delta +0, disk usage +4.8KiB).
+```
+### lock change:
+```
+• Updated input 'emacs-overlay':
+    'github:nix-community/emacs-overlay/f95c33d692cc174df41e40330aec4abf2a94b673' (2023-06-16)
+  → 'github:nix-community/emacs-overlay/1ab94d15a82c3e4bd295f3efa8f5145b18e0d6ff' (2023-06-17)
+• Updated input 'emacs-overlay/nixpkgs':
+    'github:NixOS/nixpkgs/0eeebd64de89e4163f4d3cf34ffe925a5cf67a05' (2023-06-12)
+  → 'github:NixOS/nixpkgs/7c67f006ea0e7d0265f16d7df07cc076fdffd91f' (2023-06-15)
+• Updated input 'emacs-overlay/nixpkgs-stable':
+    'github:NixOS/nixpkgs/ddf4688dc7aeb14e8a3c549cb6aa6337f187a884' (2023-06-14)
+  → 'github:NixOS/nixpkgs/c7ff1b9b95620ce8728c0d7bd501c458e6da9e04' (2023-06-16)
+• Updated input 'home-manager':
+    'github:nix-community/home-manager/4e09c83255c5b23d58714d56672d3946faf1bcef' (2023-06-15)
+  → 'github:nix-community/home-manager/9ba7b3990eb1f4782ea3f5fe7ac4f3c88dd7a32c' (2023-06-16)
+• Updated input 'nixpkgs-master':
+    'github:NixOS/nixpkgs/610f62011e631d12869784058ea95f99fdf393d2' (2023-06-16)
+  → 'github:NixOS/nixpkgs/15052a575b51ddc367a18f0a5f41d8a5d9f07226' (2023-06-17)
+• Updated input 'nixpkgs-stable':
+    'github:NixOS/nixpkgs/aa4b53f79d961a7cbba0b24f791401a34c18011a' (2023-06-16)
+  → 'github:NixOS/nixpkgs/56799517d0537a6f3e91a5171af8c4bfd82c092e' (2023-06-17)
+• Updated input 'nixpkgs-unstable':
+    'github:NixOS/nixpkgs/683f2f5ba2ea54abb633d0b17bc9f7f6dede5799' (2023-06-15)
+  → 'github:NixOS/nixpkgs/992ccdd822ecff0712ed0004f89df9e96f6a4963' (2023-06-16)
+```
+
 ## Update 2023-06-16
 ```go
 Version changes:

--- a/flake.lock
+++ b/flake.lock
@@ -78,11 +78,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1686886849,
-        "narHash": "sha256-pBscV99gEBiC+KODEphw9IQRPcpMzudkjlzPdQIdo6g=",
+        "lastModified": 1686967317,
+        "narHash": "sha256-L9pzRhMrkWrkj6mswfFE7GpjQWJiV6pEgbTM6TcxERI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "f95c33d692cc174df41e40330aec4abf2a94b673",
+        "rev": "1ab94d15a82c3e4bd295f3efa8f5145b18e0d6ff",
         "type": "github"
       },
       "original": {
@@ -196,11 +196,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1686852570,
-        "narHash": "sha256-Hzufya/HxjSliCwpuLJCGY0WCQajzcpsnhFGa+TCkCM=",
+        "lastModified": 1686922395,
+        "narHash": "sha256-ysevinohPxdKp0RXyhDRsz1/vh1eXazg4AWp0n5X/U4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "4e09c83255c5b23d58714d56672d3946faf1bcef",
+        "rev": "9ba7b3990eb1f4782ea3f5fe7ac4f3c88dd7a32c",
         "type": "github"
       },
       "original": {
@@ -212,11 +212,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1686592866,
-        "narHash": "sha256-riGg89eWhXJcPNrQGcSwTEEm7CGxWC06oSX44hajeMw=",
+        "lastModified": 1686869522,
+        "narHash": "sha256-tbJ9B8WLCTnVP/LwESRlg0dII6Zyg2LmUU/mB9Lu98E=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0eeebd64de89e4163f4d3cf34ffe925a5cf67a05",
+        "rev": "7c67f006ea0e7d0265f16d7df07cc076fdffd91f",
         "type": "github"
       },
       "original": {
@@ -228,11 +228,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1686896455,
-        "narHash": "sha256-xLQeq3oWRdvl8j5mlAnGIhp/yu+htRVbvDnmJODbDUg=",
+        "lastModified": 1686969779,
+        "narHash": "sha256-/6hoNKGsgzFHhUZ5vdhfNrVoQNzWOpQJSsEIGUj1E2c=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "610f62011e631d12869784058ea95f99fdf393d2",
+        "rev": "15052a575b51ddc367a18f0a5f41d8a5d9f07226",
         "type": "github"
       },
       "original": {
@@ -244,11 +244,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1686736559,
-        "narHash": "sha256-YyUSVoOKIDAscTx7IZhF9x3qgZ9dPNF19fKk+4c5irc=",
+        "lastModified": 1686921029,
+        "narHash": "sha256-J1bX9plPCFhTSh6E3TWn9XSxggBh/zDD4xigyaIQBy8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ddf4688dc7aeb14e8a3c549cb6aa6337f187a884",
+        "rev": "c7ff1b9b95620ce8728c0d7bd501c458e6da9e04",
         "type": "github"
       },
       "original": {
@@ -260,11 +260,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1686885751,
-        "narHash": "sha256-KcbYp2KuKbXgNaYVziwKUc6AKRhgJ1G8Qq5gjAbQ3uw=",
+        "lastModified": 1686968143,
+        "narHash": "sha256-NkXmT9ArJBeu56jo/agURQ1pvqrx0nUHi30yM7sttK8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "aa4b53f79d961a7cbba0b24f791401a34c18011a",
+        "rev": "56799517d0537a6f3e91a5171af8c4bfd82c092e",
         "type": "github"
       },
       "original": {
@@ -276,11 +276,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1686828063,
-        "narHash": "sha256-Cv0Sx1N5+3xBDF5OnmFU3Qoh9OqZmXDBKg1fgXlXTWs=",
+        "lastModified": 1686949509,
+        "narHash": "sha256-52OTWmIjf5t5VcoGhSjRsCWHlwSf/mPhY+0fpaiA1hs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "683f2f5ba2ea54abb633d0b17bc9f7f6dede5799",
+        "rev": "992ccdd822ecff0712ed0004f89df9e96f6a4963",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Update 2023-06-17
```go
Version changes:
[U.]  #1  tree  2.0.4 -> 2.1.1
Closure size: 681 -> 681 (5 paths added, 5 paths removed, delta +0, disk usage +4.8KiB).
```
### lock change:
```
• Updated input 'emacs-overlay':
    'github:nix-community/emacs-overlay/f95c33d692cc174df41e40330aec4abf2a94b673' (2023-06-16)
  → 'github:nix-community/emacs-overlay/1ab94d15a82c3e4bd295f3efa8f5145b18e0d6ff' (2023-06-17)
• Updated input 'emacs-overlay/nixpkgs':
    'github:NixOS/nixpkgs/0eeebd64de89e4163f4d3cf34ffe925a5cf67a05' (2023-06-12)
  → 'github:NixOS/nixpkgs/7c67f006ea0e7d0265f16d7df07cc076fdffd91f' (2023-06-15)
• Updated input 'emacs-overlay/nixpkgs-stable':
    'github:NixOS/nixpkgs/ddf4688dc7aeb14e8a3c549cb6aa6337f187a884' (2023-06-14)
  → 'github:NixOS/nixpkgs/c7ff1b9b95620ce8728c0d7bd501c458e6da9e04' (2023-06-16)
• Updated input 'home-manager':
    'github:nix-community/home-manager/4e09c83255c5b23d58714d56672d3946faf1bcef' (2023-06-15)
  → 'github:nix-community/home-manager/9ba7b3990eb1f4782ea3f5fe7ac4f3c88dd7a32c' (2023-06-16)
• Updated input 'nixpkgs-master':
    'github:NixOS/nixpkgs/610f62011e631d12869784058ea95f99fdf393d2' (2023-06-16)
  → 'github:NixOS/nixpkgs/15052a575b51ddc367a18f0a5f41d8a5d9f07226' (2023-06-17)
• Updated input 'nixpkgs-stable':
    'github:NixOS/nixpkgs/aa4b53f79d961a7cbba0b24f791401a34c18011a' (2023-06-16)
  → 'github:NixOS/nixpkgs/56799517d0537a6f3e91a5171af8c4bfd82c092e' (2023-06-17)
• Updated input 'nixpkgs-unstable':
    'github:NixOS/nixpkgs/683f2f5ba2ea54abb633d0b17bc9f7f6dede5799' (2023-06-15)
  → 'github:NixOS/nixpkgs/992ccdd822ecff0712ed0004f89df9e96f6a4963' (2023-06-16)
```
